### PR TITLE
Feat/#6 알림 생성 기능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/groommoa/aether_back_notification/AetherBackNotificationApplication.java
+++ b/src/main/java/com/groommoa/aether_back_notification/AetherBackNotificationApplication.java
@@ -2,8 +2,10 @@ package com.groommoa.aether_back_notification;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
+@EnableMongoAuditing
 public class AetherBackNotificationApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
@@ -1,15 +1,42 @@
 package com.groommoa.aether_back_notification.domain.notifications.controller;
 
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.groommoa.aether_back_notification.domain.notifications.dto.CreateNotificationRequestDto;
+import com.groommoa.aether_back_notification.domain.notifications.entity.Notification;
+import com.groommoa.aether_back_notification.domain.notifications.service.NotificationService;
+import com.groommoa.aether_back_notification.global.common.constants.HttpStatus;
+import com.groommoa.aether_back_notification.global.common.response.CommonResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RequestMapping("/notifications")
+@RequiredArgsConstructor
 @RestController
 public class NotificationController {
 
-    @GetMapping("")
-    public String eurekaTest() {
-        return "eurekaTest";
+    private final NotificationService notificationService;
+
+    @PostMapping("")
+    public ResponseEntity<CommonResponse> createNotification(@RequestBody @Valid CreateNotificationRequestDto request){
+        Notification notification = notificationService.createNotification(request);
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("message", notification.getMessage());
+        result.put("sender", notification.getSender().toString());
+        result.put("receiver", notification.getReceiver().toString());
+        result.put("noticeType", notification.getNoticeType());
+        result.put("relatedContent", notification.getRelatedContent());
+        result.put("isRead", notification.isRead());
+        result.put("createdAt", notification.getCreatedAt());
+        result.put("updatedAt", notification.getUpdatedAt());
+
+        CommonResponse response = new CommonResponse(
+                HttpStatus.OK, "알림 생성에 성공했습니다.", result
+        );
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
@@ -1,0 +1,32 @@
+package com.groommoa.aether_back_notification.domain.notifications.dto;
+
+import com.groommoa.aether_back_notification.domain.notifications.entity.NoticeType;
+import com.groommoa.aether_back_notification.domain.notifications.entity.RelatedContent;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.types.ObjectId;
+
+@Getter
+@Setter
+public class CreateNotificationRequestDto {
+
+    @NotBlank
+    private String message;
+
+    @NotNull
+    private ObjectId sender;
+
+    @NotNull
+    private ObjectId receiver;
+
+    @NotNull
+    private NoticeType noticeType;
+
+    @NotNull
+    private RelatedContent relatedContent;
+
+    private boolean isRead;
+
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
@@ -2,6 +2,7 @@ package com.groommoa.aether_back_notification.domain.notifications.dto;
 
 import com.groommoa.aether_back_notification.domain.notifications.entity.NoticeType;
 import com.groommoa.aether_back_notification.domain.notifications.entity.RelatedContent;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -12,19 +13,20 @@ import org.bson.types.ObjectId;
 @Setter
 public class CreateNotificationRequestDto {
 
-    @NotBlank
+    @NotBlank(message = "message 필드는 null 값이거나 공백일 수 없습니다.")
     private String message;
 
-    @NotNull
+    @NotNull(message = "sender 필드는 null 값일 수 없습니다.")
     private ObjectId sender;
 
-    @NotNull
+    @NotNull(message = "receiver 필드는 null 값일 수 없습니다.")
     private ObjectId receiver;
 
-    @NotNull
+    @NotNull(message = "noticeType 필드는 null 값일 수 없습니다.")
     private NoticeType noticeType;
 
-    @NotNull
+    @Valid
+    @NotNull(message = "relatedContent 필드는 null 값일 수 없습니다.")
     private RelatedContent relatedContent;
 
     private boolean isRead;

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/NoticeType.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/NoticeType.java
@@ -1,5 +1,6 @@
 package com.groommoa.aether_back_notification.domain.notifications.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -14,4 +15,9 @@ public enum NoticeType {
     PROJECT_ADDED("project_added");
 
     private final String key;
+
+    @JsonCreator
+    public static NoticeType from(String value){
+        return value != null ? NoticeType.valueOf(value.toUpperCase()) : null;
+    }
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/NoticeType.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/NoticeType.java
@@ -1,0 +1,17 @@
+package com.groommoa.aether_back_notification.domain.notifications.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeType {
+    TASK_ASSIGNED("task_assigned"),
+    TASK_UPDATED("task_updated"),
+    TASK_DEADLINE("task_deadline"),
+    COMMENT_ADDED("comment_added"),
+    DOCUMENT_UPLOADED("document_uploaded"),
+    PROJECT_ADDED("project_added");
+
+    private final String key;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
@@ -1,0 +1,48 @@
+package com.groommoa.aether_back_notification.domain.notifications.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document(collection = "notifications")
+@Getter
+public class Notification {
+
+    @Id
+    private ObjectId id;
+
+    private String message;
+
+    private ObjectId sender;
+
+    private ObjectId receiver;
+
+    private NoticeType noticeType;
+
+    private RelatedContent relatedContent;
+
+    private boolean isRead;
+
+    @CreatedDate
+    private Instant createdAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
+
+    @Builder
+    public Notification(String message, ObjectId sender, ObjectId receiver, NoticeType noticeType,
+                        RelatedContent relatedContent, boolean isRead) {
+        this.message = message;
+        this.sender = sender;
+        this.receiver = receiver;
+        this.noticeType = noticeType;
+        this.relatedContent = relatedContent;
+        this.isRead = isRead;
+    }
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
@@ -1,9 +1,7 @@
 package com.groommoa.aether_back_notification.domain.notifications.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
 import org.bson.types.ObjectId;
 
 @Getter
@@ -12,6 +10,9 @@ import org.bson.types.ObjectId;
 @AllArgsConstructor
 public class RelatedContent {
 
+    @NotBlank(message = "relatedContent의 id는 null 값이거나 공백일 수 없습니다.")
     private String id;
+
+    @NotBlank(message = "relatedContent의 type은 null 값이거나 공백일 수 없습니다.")
     private String type;
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
@@ -1,0 +1,17 @@
+package com.groommoa.aether_back_notification.domain.notifications.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.bson.types.ObjectId;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RelatedContent {
+
+    private String id;
+    private String type;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/repository/NotificationRepository.java
@@ -1,0 +1,7 @@
+package com.groommoa.aether_back_notification.domain.notifications.repository;
+
+import com.groommoa.aether_back_notification.domain.notifications.entity.Notification;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface NotificationRepository extends MongoRepository<Notification, String> {
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
@@ -1,0 +1,33 @@
+package com.groommoa.aether_back_notification.domain.notifications.service;
+
+import com.groommoa.aether_back_notification.domain.notifications.dto.CreateNotificationRequestDto;
+import com.groommoa.aether_back_notification.domain.notifications.entity.Notification;
+import com.groommoa.aether_back_notification.domain.notifications.entity.RelatedContent;
+import com.groommoa.aether_back_notification.domain.notifications.repository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+
+    @Transactional
+    public Notification createNotification(CreateNotificationRequestDto request) {
+        Notification notification = Notification.builder()
+                .message(request.getMessage())
+                .sender(request.getSender())
+                .receiver(request.getReceiver())
+                .noticeType(request.getNoticeType())
+                .relatedContent(RelatedContent.builder()
+                        .id(request.getRelatedContent().getId())
+                        .type(request.getRelatedContent().getType())
+                        .build())
+                .isRead(request.isRead())
+                .build();
+        return notificationRepository.save(notification);
+    }
+}

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/constants/HttpStatus.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/constants/HttpStatus.java
@@ -3,7 +3,9 @@ package com.groommoa.aether_back_notification.global.common.constants;
 public final class HttpStatus {
 
     public static final int OK = 200;
+    public static final int BAD_REQUEST = 400;
     public static final int UNAUTHORIZED = 401;
     public static final int MOVED_PERMANENTLY = 301;
+    public static final int INTERNAL_SERVER_ERROR = 500;
 }
 

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/constants/HttpStatus.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/constants/HttpStatus.java
@@ -1,0 +1,9 @@
+package com.groommoa.aether_back_notification.global.common.constants;
+
+public final class HttpStatus {
+
+    public static final int OK = 200;
+    public static final int UNAUTHORIZED = 401;
+    public static final int MOVED_PERMANENTLY = 301;
+}
+

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/handler/GlobalExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.groommoa.aether_back_notification.global.common.handler;
+
+import com.groommoa.aether_back_notification.global.common.constants.HttpStatus;
+import com.groommoa.aether_back_notification.global.common.response.ErrorResponse;
+import com.mongodb.MongoException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
+        List<Map<String, String>> errors = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> Map.of(
+                        "field", error.getField(),
+                        "reason", error.getDefaultMessage()
+                ))
+                .toList();
+
+        Map<String, Object> details = Map.of("errors", errors);
+
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.BAD_REQUEST, "유효하지 않은 입력값입니다.", details
+        );
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(MongoException.class)
+    public ResponseEntity<ErrorResponse> handleMongoException(MongoException ex) {
+        ex.printStackTrace();
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR, "데이터베이스 오류가 발생했습니다.", null);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception ex) {
+        ex.printStackTrace();
+        ErrorResponse response = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", null);
+
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+}

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/response/CommonResponse.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/response/CommonResponse.java
@@ -1,0 +1,15 @@
+package com.groommoa.aether_back_notification.global.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class CommonResponse {
+
+    private final int code;
+    private final String message;
+    private final Map<String, Object> result;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/response/ErrorResponse.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/response/ErrorResponse.java
@@ -1,0 +1,16 @@
+package com.groommoa.aether_back_notification.global.common.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponse {
+
+    private final int code;
+    private final String message;
+    private final Map<String, Object> details;
+
+}


### PR DESCRIPTION
# Changes

## 1. 알림 생성 api 추가

### [POST] /notifications

알림을 생성합니다.

#### Headers

| 헤더명         | 필수 | 설명                                  |
|----------------|------|----------------------------------------|
| `Content-Type` | ✅   | `application/json`                    |
| `Authorization`| ✅   | `Bearer {JWT_TOKEN}` |

#### Request Body

| 필드명           | 타입      | 필수 | 설명                                   |
|------------------|-----------|------|----------------------------------------|
| `message`        | `String`  | ✅   | 알림에 표시될 메시지 내용              |
| `sender`         | `ObjectId (String)`| ✅   | 알림을 보낸 유저의 MongoDB ObjectId   |
| `receiver`       | `ObjectId (String)`| ✅   | 알림을 받을 유저의 MongoDB ObjectId   |
| `noticeType`     | `String`  | ✅   | 알림 유형 Enum|
| └─ `id`          | `ObjectId (String)` | ✅   | 연관된 컨텐츠 MongoDB ObjectId|
| └─ `type`        | `String`            | ✅   | 연관된 컨텐츠 유형 Enum |
| `relatedContent` | `Object`  | ✅   | 알림과 연관된 컨텐츠 정보 |
| `isRead`         | `Boolean` | ✅   | 읽음 여부 |

#### Request Body - Example
```
{
    "message": "알림을 위한 Task 생성 업무가 할당되었습니다.",
    "sender": "67ab0a78f7f3db366f94dd29",
    "noticeType": "task_assigned",
    "relatedContent": {
        "id": "67e2f1b67cfb27cc9bd7922f",
        "type": "Task"
    },
    "isRead": false
}
```

#### Response Body

| 필드명           | 타입                | 설명                                                         |
|------------------|---------------------|--------------------------------------------------------------|
| `message`        | `String`            | 알림 메시지                                                  |
| `sender`         | `ObjectId (String)` | 보낸 사람의 MongoDB ObjectId   |
| `receiver`       | `ObjectId (String)` | 받을 사람의 MongoDB ObjectId   |
| `noticeType`     | `String`            | 알림 유형 Enum  |
| `relatedContent` | `Object`            | 알림과 연관된 컨텐츠 정보                                    |
| └─ `id`          | `ObjectId (String)` | 연관된 컨텐츠 MongoDB ObjectId   |
| └─ `type`        | `String`            | 연관된 컨텐츠 유형 Enum |
| `isRead`         | `Boolean`           | 읽음 여부 |
| `createdAt`      | `String (ISO-8601)` | 알림 생성 시간  |
| `updatedAt`      | `String (ISO-8601)` | 알림 생성 시간  |

#### Response Body - Example

**200 - OK**
```
{
    "code": 200,
    "message": "알림 생성에 성공했습니다.",
    "result": {
        "message": "알림을 위한 Task 생성 업무가 할당되었습니다.",
        "sender": "67ab0a78f7f3db366f94dd29",
        "receiver": "67c1ba6f9aac326b49424b1d",
        "noticeType": "task_assigned",
        "relatedContent": {
            "id": "67e2f1b67cfb27cc9bd7922f",
            "type": "Task"
        },
        "isRead": false
        "createdAt": "2025-04-07T11:15:30.456Z"
        "updatedAt": "2025-04-07T11:15:30.456Z"
    }
}
```

**400 - Bad Request**
```
{
    "code": 400,
    "message": "유효하지 않은 입력값입니다.",
    "details": {
        "errors": [
            {
                "reason": "sender 필드는 null 값일 수 없습니다.",
                "field": "sender"
            },
            {
                "reason": "relatedContent 필드는 null 값일 수 없습니다.",
                "field": "relatedContent"
            }
        ]
    }
}
```

#### Enum - noticeType

| 값              | 설명                         |
|------------------|------------------------------|
| `task_assigned`        | 사용자가 새로운 업무를 배정받음 |
| `task_updated`           | 업무 내용이 업데이트됨  |
| `task_deadline`         | 마감일이 임박하거나 지난 업무 |
| `comment_added`  | 업무에 새로운 코멘트가 추가됨 |
| `document_uploaded`  | 업무에 새로운 문서가 업로드됨 |
| `project_added`  | 새로운 참여 프로젝트가 추가됨 |

#### Enum - relatedContent.type

| 값              | 설명                         |
|------------------|------------------------------|
| `Task`        | 업무 |
| `Comment`           | 코멘트  |
| `Document`         | 문서 |