### PR TITLE
feat: 알림 생성 api 수정

### DIFF
--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/NoticeType.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/NoticeType.java
@@ -1,4 +1,4 @@
-package com.groommoa.aether_back_notification.domain.notifications.entity;
+package com.groommoa.aether_back_notification.domain.notifications.common;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.Getter;

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/RelatedContentType.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/RelatedContentType.java
@@ -1,0 +1,14 @@
+package com.groommoa.aether_back_notification.domain.notifications.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RelatedContentType {
+    Task("TASK"),
+    Comment("COMMENT"),
+    Document("DOCUMENT");
+
+    private final String key;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
@@ -1,10 +1,12 @@
 package com.groommoa.aether_back_notification.domain.notifications.controller;
 
 import com.groommoa.aether_back_notification.domain.notifications.dto.CreateNotificationRequestDto;
+import com.groommoa.aether_back_notification.domain.notifications.dto.CreateNotificationResponseDto;
 import com.groommoa.aether_back_notification.domain.notifications.entity.Notification;
 import com.groommoa.aether_back_notification.domain.notifications.service.NotificationService;
 import com.groommoa.aether_back_notification.global.common.constants.HttpStatus;
 import com.groommoa.aether_back_notification.global.common.response.CommonResponse;
+import com.groommoa.aether_back_notification.global.common.utils.DtoUtils;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,13 +25,12 @@ public class NotificationController {
     @PostMapping("")
     public ResponseEntity<CommonResponse> createNotification(@RequestBody @Valid CreateNotificationRequestDto request){
         Notification notification = notificationService.createNotification(request);
+        CreateNotificationResponseDto responseDto = new CreateNotificationResponseDto(notification);
 
-        Map<String, Object> result = new HashMap<>();
-        result.put("notification", notification);
 
         CommonResponse response = new CommonResponse(
-                HttpStatus.OK, "알림 생성에 성공했습니다.", result
-        );
+                HttpStatus.OK, "알림 생성에 성공했습니다.", DtoUtils.toMap(responseDto));
+
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
@@ -25,14 +25,7 @@ public class NotificationController {
         Notification notification = notificationService.createNotification(request);
 
         Map<String, Object> result = new HashMap<>();
-        result.put("message", notification.getMessage());
-        result.put("sender", notification.getSender().toString());
-        result.put("receiver", notification.getReceiver().toString());
-        result.put("noticeType", notification.getNoticeType());
-        result.put("relatedContent", notification.getRelatedContent());
-        result.put("isRead", notification.isRead());
-        result.put("createdAt", notification.getCreatedAt());
-        result.put("updatedAt", notification.getUpdatedAt());
+        result.put("notification", notification);
 
         CommonResponse response = new CommonResponse(
                 HttpStatus.OK, "알림 생성에 성공했습니다.", result

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
@@ -12,13 +12,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @RequestMapping("/notifications")
 @RequiredArgsConstructor
 @RestController
 public class NotificationController {
+
 
     private final NotificationService notificationService;
 

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
@@ -1,35 +1,35 @@
 package com.groommoa.aether_back_notification.domain.notifications.dto;
 
-import com.groommoa.aether_back_notification.domain.notifications.entity.NoticeType;
-import com.groommoa.aether_back_notification.domain.notifications.entity.RelatedContent;
+import com.groommoa.aether_back_notification.domain.notifications.common.NoticeType;
+import com.groommoa.aether_back_notification.global.common.validation.ValidEnum;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-import org.bson.types.ObjectId;
 
 @Getter
 @Setter
 public class CreateNotificationRequestDto {
 
     @NotNull(message = "project 필드는 null 값일 수 없습니다.")
-    private ObjectId project;
+    private String project;
 
     @NotBlank(message = "message 필드는 null 값이거나 공백일 수 없습니다.")
     private String message;
 
-    private ObjectId sender;
+    private String sender;
 
     @NotNull(message = "receiver 필드는 null 값일 수 없습니다.")
-    private ObjectId receiver;
+    private String receiver;
 
+    @ValidEnum(enumClass = NoticeType.class, message = "noticeType이 유효하지 않습니다.")
     @NotNull(message = "noticeType 필드는 null 값일 수 없습니다.")
     private NoticeType noticeType;
 
     @Valid
     @NotNull(message = "relatedContent 필드는 null 값일 수 없습니다.")
-    private RelatedContent relatedContent;
+    private RelatedContentDto relatedContent;
 
     private boolean isRead;
 

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationRequestDto.java
@@ -13,10 +13,12 @@ import org.bson.types.ObjectId;
 @Setter
 public class CreateNotificationRequestDto {
 
+    @NotNull(message = "project 필드는 null 값일 수 없습니다.")
+    private ObjectId project;
+
     @NotBlank(message = "message 필드는 null 값이거나 공백일 수 없습니다.")
     private String message;
 
-    @NotNull(message = "sender 필드는 null 값일 수 없습니다.")
     private ObjectId sender;
 
     @NotNull(message = "receiver 필드는 null 값일 수 없습니다.")

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationResponseDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationResponseDto.java
@@ -2,9 +2,11 @@ package com.groommoa.aether_back_notification.domain.notifications.dto;
 
 import com.groommoa.aether_back_notification.domain.notifications.common.NoticeType;
 import com.groommoa.aether_back_notification.domain.notifications.entity.Notification;
+import lombok.Getter;
 
 import java.time.Instant;
 
+@Getter
 public class CreateNotificationResponseDto {
 
     private final String message;

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationResponseDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationResponseDto.java
@@ -1,0 +1,32 @@
+package com.groommoa.aether_back_notification.domain.notifications.dto;
+
+import com.groommoa.aether_back_notification.domain.notifications.common.NoticeType;
+import com.groommoa.aether_back_notification.domain.notifications.entity.Notification;
+
+import java.time.Instant;
+
+public class CreateNotificationResponseDto {
+
+    private final String message;
+    private final String sender;
+    private final String receiver;
+    private final NoticeType noticeType;
+    private final RelatedContentDto relatedContent;
+    private final boolean isRead;
+    private final Instant createdAt;
+    private final Instant updatedAt;
+
+    public CreateNotificationResponseDto(Notification notification) {
+        this.message = notification.getMessage();
+        this.sender = notification.getSender().toHexString();
+        this.receiver = notification.getReceiver().toHexString();
+        this.noticeType = notification.getNoticeType();
+        this.relatedContent = RelatedContentDto.builder()
+                .id(notification.getRelatedContent().getId().toHexString())
+                .type(notification.getRelatedContent().getType())
+                .build();
+        this.isRead = notification.isRead();
+        this.createdAt = notification.getCreatedAt();
+        this.updatedAt = notification.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/RelatedContentDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/RelatedContentDto.java
@@ -1,0 +1,21 @@
+package com.groommoa.aether_back_notification.domain.notifications.dto;
+
+import com.groommoa.aether_back_notification.domain.notifications.common.RelatedContentType;
+import com.groommoa.aether_back_notification.global.common.validation.ValidEnum;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RelatedContentDto {
+
+    @NotBlank(message = "relatedContent의 id는 null 값이거나 공백일 수 없습니다.")
+    private String id;
+
+    @ValidEnum(enumClass = RelatedContentType.class, message = "relatedContent의 type이 유효하지 않습니다.")
+    @NotNull(message = "relatedContent의 type은 null 값일 수 없습니다.")
+    private RelatedContentType type;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/NoticeType.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/NoticeType.java
@@ -11,8 +11,10 @@ public enum NoticeType {
     TASK_UPDATED("task_updated"),
     TASK_DEADLINE("task_deadline"),
     COMMENT_ADDED("comment_added"),
+    COMMENT_UPDATED("comment_updated"),
     DOCUMENT_UPLOADED("document_uploaded"),
-    PROJECT_ADDED("project_added");
+    PROJECT_ADDED("project_added"),
+    PROJECT_UPDATED("project_updated"),;
 
     private final String key;
 

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
@@ -11,15 +11,19 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import java.time.Instant;
 
 @Document(collection = "notifications")
+@Builder
 @Getter
 public class Notification {
 
     @Id
     private ObjectId id;
 
+    private ObjectId project;
+
     private String message;
 
-    private ObjectId sender;
+    @Builder.Default
+    private ObjectId sender = null;
 
     private ObjectId receiver;
 
@@ -27,22 +31,12 @@ public class Notification {
 
     private RelatedContent relatedContent;
 
-    private boolean isRead;
+    @Builder.Default
+    private boolean isRead = false;
 
     @CreatedDate
     private Instant createdAt;
 
     @LastModifiedDate
     private Instant updatedAt;
-
-    @Builder
-    public Notification(String message, ObjectId sender, ObjectId receiver, NoticeType noticeType,
-                        RelatedContent relatedContent, boolean isRead) {
-        this.message = message;
-        this.sender = sender;
-        this.receiver = receiver;
-        this.noticeType = noticeType;
-        this.relatedContent = relatedContent;
-        this.isRead = isRead;
-    }
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
@@ -1,5 +1,6 @@
 package com.groommoa.aether_back_notification.domain.notifications.entity;
 
+import com.groommoa.aether_back_notification.domain.notifications.common.NoticeType;
 import lombok.Builder;
 import lombok.Getter;
 import org.bson.types.ObjectId;

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
@@ -1,6 +1,6 @@
 package com.groommoa.aether_back_notification.domain.notifications.entity;
 
-import jakarta.validation.constraints.NotBlank;
+import com.groommoa.aether_back_notification.domain.notifications.common.RelatedContentType;
 import lombok.*;
 import org.bson.types.ObjectId;
 
@@ -10,9 +10,7 @@ import org.bson.types.ObjectId;
 @AllArgsConstructor
 public class RelatedContent {
 
-    @NotBlank(message = "relatedContent의 id는 null 값이거나 공백일 수 없습니다.")
-    private String id;
+    private ObjectId id;
 
-    @NotBlank(message = "relatedContent의 type은 null 값이거나 공백일 수 없습니다.")
-    private String type;
+    private RelatedContentType type;
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
@@ -18,13 +18,13 @@ public class NotificationService {
     @Transactional
     public Notification createNotification(CreateNotificationRequestDto request) {
         Notification notification = Notification.builder()
-                .project(request.getProject())
+                .project(new ObjectId(request.getProject()))
                 .message(request.getMessage())
-                .sender(request.getSender())
-                .receiver(request.getReceiver())
+                .sender(new ObjectId(request.getSender()))
+                .receiver(new ObjectId(request.getReceiver()))
                 .noticeType(request.getNoticeType())
                 .relatedContent(RelatedContent.builder()
-                        .id(request.getRelatedContent().getId())
+                        .id(new ObjectId(request.getRelatedContent().getId()))
                         .type(request.getRelatedContent().getType())
                         .build())
                 .isRead(request.isRead())

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
@@ -18,6 +18,7 @@ public class NotificationService {
     @Transactional
     public Notification createNotification(CreateNotificationRequestDto request) {
         Notification notification = Notification.builder()
+                .project(request.getProject())
                 .message(request.getMessage())
                 .sender(request.getSender())
                 .receiver(request.getReceiver())

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/handler/GlobalExceptionHandler.java
@@ -1,22 +1,91 @@
 package com.groommoa.aether_back_notification.global.common.handler;
 
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.MismatchedInputException;
 import com.groommoa.aether_back_notification.global.common.constants.HttpStatus;
 import com.groommoa.aether_back_notification.global.common.response.ErrorResponse;
 import com.mongodb.MongoException;
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.bson.types.ObjectId;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        Throwable cause = ExceptionUtils.getRootCause(ex);
+        if (cause == null) cause = ex.getCause();
+
+        String message = "유효하지 않은 입력값입니다.";
+        List<Map<String, String>> errors = new ArrayList<>();
+
+        if (cause instanceof InvalidFormatException ife) {
+            Class<?> targetType = ife.getTargetType();
+            Object invalidValue = ife.getValue();
+            String field = extractFieldFromPath(ife.getPathReference());
+
+            if (targetType.isEnum()) {
+                message = String.format("'%s'은(는) 지원하지 않는 값입니다.", invalidValue);
+                errors.add(Map.of(
+                        "field", field,
+                        "reason", String.format("가능한 값: %s", Arrays.toString(targetType.getEnumConstants()))
+                ));
+            } else if (targetType == ObjectId.class) {
+                message = "잘못된 ObjectId 형식입니다.";
+                errors.add(Map.of(
+                        "field", field,
+                        "reason", String.format("'%s'은(는) 올바르지 않은 ObjectId입니다.", invalidValue)
+                ));
+            } else {
+                message = "입력값 형식 오류";
+                errors.add(Map.of(
+                        "field", field,
+                        "reason", String.format("'%s'은(는) %s 타입으로 변환할 수 없습니다.",
+                                invalidValue, targetType.getSimpleName())
+                ));
+            }
+        } else if (cause instanceof IllegalArgumentException iae && iae.getMessage() != null) {
+            String msg = iae.getMessage();
+            if (msg.contains("No enum constant")) {
+                try {
+                    String[] parts = msg.split("No enum constant ")[1].split("\\.");
+                    String className = String.join(".", Arrays.copyOf(parts, parts.length - 1));
+                    String invalidValue = parts[parts.length - 1];
+                    String simpleClassName = className.substring(className.lastIndexOf(".") + 1);
+
+                    message = "Enum 값이 올바르지 않습니다.";
+                    errors.add(Map.of(
+                            "field", simpleClassName,
+                            "reason", String.format("'%s'은(는) %s에서 지원하지 않는 Enum 값입니다. 대소문자나 오타를 확인해주세요.",
+                                    invalidValue, simpleClassName)
+                    ));
+                } catch (Exception e) {
+                    message = "Enum 값이 올바르지 않습니다.";
+                }
+            } else {
+                message = msg;
+            }
+        } else if (cause instanceof MismatchedInputException) {
+            message = "입력값의 형식이 맞지 않습니다.";
+        } else if (cause instanceof JsonParseException) {
+            message = "잘못된 JSON 형식입니다.";
+        } else message = Objects.requireNonNullElse(cause, ex).getMessage();
+
+        Map<String, Object> details = errors.isEmpty() ? null : Map.of("errors", errors);
+        ErrorResponse response = new ErrorResponse(HttpStatus.BAD_REQUEST, message, details);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex) {
@@ -35,6 +104,7 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
+
     @ExceptionHandler(MongoException.class)
     public ResponseEntity<ErrorResponse> handleMongoException(MongoException ex) {
         ex.printStackTrace();
@@ -51,5 +121,15 @@ public class GlobalExceptionHandler {
                 HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.", null);
 
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    private String extractFieldFromPath(String pathReference) {
+        if (pathReference == null) return "unknown";
+        int start = pathReference.lastIndexOf("[\"") + 2;
+        int end = pathReference.lastIndexOf("\"]");
+        if (start > 1 && end > start) {
+            return pathReference.substring(start, end);
+        }
+        return "unknown";
     }
 }

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/utils/DtoUtils.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/utils/DtoUtils.java
@@ -2,12 +2,24 @@ package com.groommoa.aether_back_notification.global.common.utils;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
 import java.util.Map;
 
+@Component
 public class DtoUtils {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper injectedObjectMapper;
+
+    private static ObjectMapper objectMapper;
+
+    @PostConstruct
+    public void init() {
+        objectMapper = injectedObjectMapper;
+    }
 
     public static Map<String, Object> toMap(Object dto){
         return objectMapper.convertValue(dto, new TypeReference<>() {});

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/utils/DtoUtils.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/utils/DtoUtils.java
@@ -1,0 +1,15 @@
+package com.groommoa.aether_back_notification.global.common.utils;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Map;
+
+public class DtoUtils {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    public static Map<String, Object> toMap(Object dto){
+        return objectMapper.convertValue(dto, new TypeReference<>() {});
+    }
+}

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/validation/EnumValidator.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/validation/EnumValidator.java
@@ -1,0 +1,26 @@
+package com.groommoa.aether_back_notification.global.common.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+import java.util.Arrays;
+
+public class EnumValidator implements ConstraintValidator<ValidEnum, String> {
+
+    private Class<? extends Enum<?>> enumClass;
+    private boolean ignoreCase;
+
+    @Override
+    public void initialize(ValidEnum annotation) {
+        this.enumClass = annotation.enumClass();
+        this.ignoreCase = annotation.ignoreCase();
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) return true; // @NotNull로 검증
+        return Arrays.stream(enumClass.getEnumConstants())
+                .map(Enum::name)
+                .anyMatch(e -> ignoreCase ? e.equalsIgnoreCase(value) : e.equals(value));
+    }
+}

--- a/src/main/java/com/groommoa/aether_back_notification/global/common/validation/ValidEnum.java
+++ b/src/main/java/com/groommoa/aether_back_notification/global/common/validation/ValidEnum.java
@@ -1,0 +1,17 @@
+package com.groommoa.aether_back_notification.global.common.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.Documented;
+
+@Documented
+@Constraint(validatedBy = EnumValidator.class)
+public @interface ValidEnum {
+    String message() default "유효하지 않은 Enum 값입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+
+    Class<? extends Enum<?>> enumClass();
+    boolean ignoreCase() default false;
+}


### PR DESCRIPTION
# Changes

## 1. 알림 생성 api 수정

- Request Body, Response Body에 project 필드 추가 (필수값)
- noticeType Enum 수정

| 추가된 Type | 설명 |
| ------- | ------- |
| comment_updated | 업무의 코멘트가 업데이트됨 |
| project_updated | 프로젝트 상태가 업데이트됨 |

- project entity 수정: sender, isRead 필드에 default 값 설정