### PR TITLE
Feat/#13 notification 스키마 변경에 따른 알림 생성 api 수정

### DIFF
--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/NoticeType.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/NoticeType.java
@@ -14,7 +14,7 @@ public enum NoticeType {
     COMMENT_ADDED("comment_added"),
     COMMENT_UPDATED("comment_updated"),
     DOCUMENT_UPLOADED("document_uploaded"),
-    PROJECT_ADDED("project_added"),
+    PROJECT_ASSIGNED("project_assigned"),
     PROJECT_UPDATED("project_updated"),;
 
     private final String key;

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/RelatedContentType.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/common/RelatedContentType.java
@@ -8,7 +8,8 @@ import lombok.RequiredArgsConstructor;
 public enum RelatedContentType {
     Task("TASK"),
     Comment("COMMENT"),
-    Document("DOCUMENT");
+    Document("DOCUMENT"),
+    Project("PROJECT");
 
     private final String key;
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationResponseDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/CreateNotificationResponseDto.java
@@ -26,6 +26,8 @@ public class CreateNotificationResponseDto {
         this.relatedContent = RelatedContentDto.builder()
                 .id(notification.getRelatedContent().getId())
                 .type(notification.getRelatedContent().getType())
+                .projectTitle(notification.getRelatedContent().getProjectTitle())
+                .taskTitle(notification.getRelatedContent().getTaskTitle())
                 .build();
         this.isRead = notification.isRead();
         this.createdAt = notification.getCreatedAt();

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/RelatedContentDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/RelatedContentDto.java
@@ -18,4 +18,9 @@ public class RelatedContentDto {
     @ValidEnum(enumClass = RelatedContentType.class, message = "relatedContent의 type이 유효하지 않습니다.")
     @NotNull(message = "relatedContent의 type은 null 값일 수 없습니다.")
     private RelatedContentType type;
+
+    @NotBlank(message = "relatedContent의 projectTitle은 null 값이거나 공백일 수 없습니다.")
+    private String projectTitle;
+
+    private String taskTitle;
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/RelatedContent.java
@@ -15,4 +15,8 @@ public class RelatedContent {
     private String id;
 
     private RelatedContentType type;
+
+    private String projectTitle;
+
+    private String taskTitle;
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/service/NotificationService.java
@@ -68,6 +68,8 @@ public class NotificationService {
                 .relatedContent(RelatedContent.builder()
                         .id(request.getRelatedContent().getId())
                         .type(request.getRelatedContent().getType())
+                        .projectTitle(request.getRelatedContent().getProjectTitle())
+                        .taskTitle(request.getRelatedContent().getTaskTitle())
                         .build())
                 .isRead(request.isRead())
                 .build();


### PR DESCRIPTION
## Changes

### 1. Notification 스키마 변경

#### RelatedContent 필드 수정


| 필드  | 변경 유형 | 타입     | 필수 여부 | 설명                               |
|:-----------:|:--------------------------------:|:----------:|:-----------:|------------------------------------|
| `relatedContent.projectTitle`  | **추가** |`String` | ✅     | 프로젝트 제목 정보 포함            |
| `relatedContent.taskTitle`     | **추가** | `String` | ❌     | 작업(Task) 제목 정보 포함          |

#### NoticeType Enum 수정

| 항목              | 변경 유형 |
|:-----------:|:-------------------:|
| `PROJECT_ADDED`    |**삭제**|
| `PROJECT_ASSIGNED` |**추가**|

#### RelatedContent.type Enum 수정

| 항목              | 변경 유형 |
|:-----------:|:-------------------:|
| `PROJECT`    |**추가** |

### 2. 알림 생성 api 수정

related link: https://github.com/9roomMoa/aether-back-notification/pull/7