### PR TITLE
feat: 알림 읽음 처리 api

### DIFF
--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
@@ -1,9 +1,6 @@
 package com.groommoa.aether_back_notification.domain.notifications.controller;
 
-import com.groommoa.aether_back_notification.domain.notifications.dto.CreateNotificationRequestDto;
-import com.groommoa.aether_back_notification.domain.notifications.dto.CreateNotificationResponseDto;
-import com.groommoa.aether_back_notification.domain.notifications.dto.NotificationPageResponseDto;
-import com.groommoa.aether_back_notification.domain.notifications.dto.NotificationResponseDto;
+import com.groommoa.aether_back_notification.domain.notifications.dto.*;
 import com.groommoa.aether_back_notification.domain.notifications.entity.Notification;
 import com.groommoa.aether_back_notification.domain.notifications.service.NotificationService;
 import com.groommoa.aether_back_notification.infrastructure.sse.service.SseService;
@@ -16,11 +13,15 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.bson.types.ObjectId;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @RequestMapping("/notifications")
@@ -73,5 +74,20 @@ public class NotificationController {
         log.info("SSE 구독 요청 둘어옴 (userId={})", userId);
 
         return sseService.subscribe(userId, lastEventId);
+    }
+
+    @PatchMapping("/read")
+    public ResponseEntity<CommonResponse> markNotificationsAsRead(
+            @AuthenticationPrincipal Claims claims,
+            @RequestBody @Valid ReadNotificationsRequestDto request
+            ) {
+        String userId = claims.getSubject();
+        ReadNotificationResponseDto responseDto = notificationService.markNotificationsAsRead(userId, request);
+
+        CommonResponse response = new CommonResponse(
+                HttpStatus.OK, "알림 읽음 요청이 처리되었습니다.", DtoUtils.toMap(responseDto)
+        );
+
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
@@ -79,7 +79,7 @@ public class NotificationController {
     @PatchMapping("/read")
     public ResponseEntity<CommonResponse> markNotificationsAsRead(
             @AuthenticationPrincipal Claims claims,
-            @RequestBody @Valid ReadNotificationsRequestDto request
+            @Valid @RequestBody ReadNotificationsRequestDto request
             ) {
         String userId = claims.getSubject();
         ReadNotificationResponseDto responseDto = notificationService.markNotificationsAsRead(userId, request);

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/ReadNotificationResponseDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/ReadNotificationResponseDto.java
@@ -1,0 +1,16 @@
+package com.groommoa.aether_back_notification.domain.notifications.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Getter
+public class ReadNotificationResponseDto {
+
+    private final List<String> updatedIds;
+    private final List<String> alreadyReadIds;
+    private final List<String> notFoundIds;
+    private final List<String> accessDeniedIds;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/ReadNotificationsRequestDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/ReadNotificationsRequestDto.java
@@ -1,0 +1,13 @@
+package com.groommoa.aether_back_notification.domain.notifications.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Getter
+public class ReadNotificationsRequestDto {
+
+    private final List<String> notificationIds;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/ReadNotificationsRequestDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/dto/ReadNotificationsRequestDto.java
@@ -1,5 +1,7 @@
 package com.groommoa.aether_back_notification.domain.notifications.dto;
 
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -9,5 +11,7 @@ import java.util.List;
 @Getter
 public class ReadNotificationsRequestDto {
 
+    @NotEmpty(message="알림 ID 목록은 비어 있을 수 없습니다.")
+    @Size(max=100, message="한번에 최대 100개의 알림한 처리할 수 있습니다.")
     private final List<String> notificationIds;
 }

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/entity/Notification.java
@@ -3,17 +3,20 @@ package com.groommoa.aether_back_notification.domain.notifications.entity;
 import com.groommoa.aether_back_notification.domain.notifications.common.NoticeType;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import org.bson.types.ObjectId;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.Instant;
 
 @Document(collection = "notifications")
 @Builder
 @Getter
+@Setter
 public class Notification {
 
     @Id
@@ -33,6 +36,7 @@ public class Notification {
     private RelatedContent relatedContent;
 
     @Builder.Default
+    @Field("isRead")
     private boolean isRead = false;
 
     @CreatedDate


### PR DESCRIPTION
## 1. 알림 읽음 처리 api 추가

### [PATCH] /notifications/read

알림 읽음 요청을 보냅니다.

#### Headers

| 헤더명         | 필수 | 설명                                  |
|----------------|------|----------------------------------------|
| `Content-Type` | ✅   | `application/json`                    |
| `Authorization`| ✅   | `Bearer {JWT_TOKEN}` |

#### Request Body

| 필드명           | 타입      | 필수 | 설명                                   |
|------------------|-----------|------|----------------------------------------|
| `notificationIds`        | `List<ObjectId (String)>`  | ✅   | 읽음 처리할 알림의 ObjectId 문자열 목록  (최대: 100개)            |

#### Request Body - Example

```
{
    "notificationIds": [
        "682769715ae5417895dcfe71",
        "682767150ec01374206ac2a7"
    ]
}
```

#### Response Body

| 필드명           | 타입                | 설명                                                         |
|------------------|---------------------|--------------------------------------------------------------|
| `updatedIds`        | `List<ObjectId (String)>`            | 읽음 처리된 알림의 ObjectId 문자열 목록  |
| `alreadyReadIds`         | `List<ObjectId (String)>` | 이전에 이미 읽음 처리된 알림의 ObjectId 문자열 목록 |
| `notFountIds`       | `List<ObjectId (String)>` | DB에서 검색되지 않은 알림의 ObjectId 문자열 목록  |
| `accessDeniedIds`     | `List<ObjectId (String)>`            | 접근이 거부된 알림의 ObjectId 문자열 목록  |

#### Response Body - Example

**200 - OK**

```
{
    "code": 200,
    "message": "알림 읽음 요청이 처리되었습니다.",
    "result": {
        "updatedIds": [],
        "alreadyReadIds": [],
        "notFoundIds": [
            "68276706ac2a7"
        ],
        "accessDeniedIds": []
    }
}
```

## Change Logs

- 2025-05-17: 알림 읽음 처리 API 최초 작성
