### PR TITLE
Feat/#25 공지 추가 api

### DIFF
--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/common/NoticeLabel.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/common/NoticeLabel.java
@@ -1,0 +1,12 @@
+package com.groommoa.aether_back_notification.domain.notices.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeLabel {
+    INTERNAL("INTERNAL");
+
+    private final String key;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/controller/NoticeController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/controller/NoticeController.java
@@ -1,0 +1,41 @@
+package com.groommoa.aether_back_notification.domain.notices.controller;
+
+import com.groommoa.aether_back_notification.domain.notices.dto.CreateNoticeRequestDto;
+import com.groommoa.aether_back_notification.domain.notices.dto.CreateNoticeResponseDto;
+import com.groommoa.aether_back_notification.domain.notices.entity.Notice;
+import com.groommoa.aether_back_notification.domain.notices.service.NoticeService;
+import com.groommoa.aether_back_notification.global.common.constants.HttpStatus;
+import com.groommoa.aether_back_notification.global.common.response.CommonResponse;
+import com.groommoa.aether_back_notification.global.common.utils.DtoUtils;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/notices")
+@RequiredArgsConstructor
+@RestController
+public class NoticeController {
+
+    private final NoticeService noticeService;
+
+    @PostMapping("")
+    public ResponseEntity<CommonResponse> createNotice(
+            @AuthenticationPrincipal Claims claims,
+            @RequestBody CreateNoticeRequestDto request
+            ) {
+        String userId = claims.getSubject();
+        Notice notice = noticeService.createNotice(userId, request);
+        CreateNoticeResponseDto responseDto = new CreateNoticeResponseDto(notice);
+
+        CommonResponse response = new CommonResponse(
+                HttpStatus.OK, "공지 생성에 성공했습니다.", DtoUtils.toMap(responseDto));
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/dto/CreateNoticeRequestDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/dto/CreateNoticeRequestDto.java
@@ -1,0 +1,10 @@
+package com.groommoa.aether_back_notification.domain.notices.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateNoticeRequestDto {
+    private String content;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/dto/CreateNoticeResponseDto.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/dto/CreateNoticeResponseDto.java
@@ -1,0 +1,18 @@
+package com.groommoa.aether_back_notification.domain.notices.dto;
+
+import com.groommoa.aether_back_notification.domain.notices.entity.Notice;
+import lombok.Getter;
+
+@Getter
+public class CreateNoticeResponseDto {
+
+    private final String content;
+    private final String createdBy;
+    private final String createdAt;
+
+    public CreateNoticeResponseDto(Notice notice) {
+        this.content = notice.getContent();
+        this.createdBy = notice.getCreatedBy().toHexString();
+        this.createdAt = notice.getCreatedAt().toString();
+    }
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/entity/Notice.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/entity/Notice.java
@@ -11,6 +11,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 
 @Document(collection = "notices")
 @Getter
@@ -21,13 +22,15 @@ public class Notice {
     @Id
     private ObjectId id;
 
-    private NoticeLabel noticeLabel;
-
-    private String title;
+    @Builder.Default
+    private NoticeLabel noticeLabel = NoticeLabel.valueOf("INTERNAL");
 
     private String content;
 
     private ObjectId createdBy;
+
+    @Builder.Default
+    private Instant expiredAt = Instant.now().plus(3, ChronoUnit.DAYS);
 
     @CreatedDate
     private Instant createdAt;

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/entity/Notice.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/entity/Notice.java
@@ -1,0 +1,37 @@
+package com.groommoa.aether_back_notification.domain.notices.entity;
+
+import com.groommoa.aether_back_notification.domain.notices.common.NoticeLabel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+import org.bson.types.ObjectId;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Document(collection = "notices")
+@Getter
+@Setter
+@Builder
+public class Notice {
+
+    @Id
+    private ObjectId id;
+
+    private NoticeLabel noticeLabel;
+
+    private String title;
+
+    private String content;
+
+    private ObjectId createdBy;
+
+    @CreatedDate
+    private Instant createdAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/entity/Notice.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/entity/Notice.java
@@ -25,7 +25,13 @@ public class Notice {
     @Builder.Default
     private NoticeLabel noticeLabel = NoticeLabel.valueOf("INTERNAL");
 
+    @Builder.Default
+    private String title = "Untitled";
+
     private String content;
+
+    @Builder.Default
+    private boolean isPinned = false;
 
     private ObjectId createdBy;
 

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/repository/NoticeRepository.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/repository/NoticeRepository.java
@@ -1,0 +1,10 @@
+package com.groommoa.aether_back_notification.domain.notices.repository;
+
+import com.groommoa.aether_back_notification.domain.notices.entity.Notice;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface NoticeRepository extends MongoRepository<Notice, String> {
+
+}

--- a/src/main/java/com/groommoa/aether_back_notification/domain/notices/service/NoticeService.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notices/service/NoticeService.java
@@ -1,0 +1,26 @@
+package com.groommoa.aether_back_notification.domain.notices.service;
+
+import com.groommoa.aether_back_notification.domain.notices.dto.CreateNoticeRequestDto;
+import com.groommoa.aether_back_notification.domain.notices.entity.Notice;
+import com.groommoa.aether_back_notification.domain.notices.repository.NoticeRepository;
+import lombok.RequiredArgsConstructor;
+import org.bson.types.ObjectId;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    @Transactional
+    public Notice createNotice(String userId, CreateNoticeRequestDto request) {
+        Notice notice = Notice.builder()
+                .content(request.getContent())
+                .createdBy(new ObjectId(userId))
+                .build();
+
+        return noticeRepository.save(notice);
+    }
+}


### PR DESCRIPTION
## 1. notice 스키마 추가

| 필드명       | 타입        | 필수 여부 | 기본값                | 설명                                   |
|--------------|-------------|-----------|------------------------|----------------------------------------|
| `id`         | `ObjectId (String)`  | ✅        | 자동 생성             | Notice ID                        |
| `title`      | `String`    | ❌        | `"Untitled"`           | 공지 제목 (더미 필드)                  |
| `content`    | `String`    | ✅        | 없음                   | 공지 내용                              |
| `noticeLabel`      | `NoticeLabel (Enum)`    | ❌        | `INTERNAL`                   | 공지 유형 |
| `isPinned`   | `Boolean`   | ❌        | `false`                | 상단 고정 여부 (더미 필드)                        |
| `createdBy`  | `ObjectId (String)`   | ✅        | `Instant.now()`        | 공지 작성자                              |
| `createdAt`  | `Date`   | ✅        | `Instant.now()`        | 생성 시각                              |
| `updatedAt`  | `Date`   | ✅        | `Instant.now()`        | 수정 시각                              |
| `expiredAt`  | `Date`   | ❌        | `createdAt + 3일`      | 만료 시각                              |

**NoticeLabel Enum**

| Enum 값     | 설명                                   |
|-------------|----------------------------------------|
| `INTERNAL`    | 사내 공지  |

## 2. 공지 추가 api

### [POST] /notices

알림 추가 요청을 보냅니다.

#### Headers

| 헤더명         | 필수 | 설명                                  |
|----------------|------|----------------------------------------|
| `Content-Type` | ✅   | `application/json`                    |
| `Authorization`| ✅   | `Bearer {JWT_TOKEN}` |

#### Request Body

| 필드명           | 타입      | 필수 | 설명                                   |
|------------------|-----------|------|----------------------------------------|
| `content`        | `String`  | ✅   | 공지 내용  |

#### Request Body - Example

```
{
    "content": "서버 점검이 예정되어 있습니다."
}
```

#### Response Body

| 필드명           | 타입                | 설명                                                         |
|------------------|---------------------|--------------------------------------------------------------|
| `content`        | `String`            | 공지 내용  |
| `createdBy`         | `ObjectId (String)` | 공지 생성자 |
| `createdAt`       | `Date (String)` | 공지 생성 시각  |

**200 - OK**

```
{
    "code": 200,
    "message": "공지 생성에 성공했습니다.",
    "result": {
        "content": "서버 점검이 예정되어 있습니다.",
        "createdBy": "67b41a721aac5e33a3f77a2e",
        "createdAt": "2025-05-21T03:43:23.426196500Z"
    }
}
```