### PR TITLE
Feat/#33: SSE 구독 api 엔드포인트 변경

### DIFF
--- a/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/domain/notifications/controller/NotificationController.java
@@ -65,17 +65,6 @@ public class NotificationController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping(value="/subscribe", produces= MediaType.TEXT_EVENT_STREAM_VALUE)
-    public SseEmitter subscribe(
-            @AuthenticationPrincipal Claims claims,
-            @RequestHeader(value="Last-Event-ID", required = false) String lastEventId
-    ) {
-        String userId = claims.getSubject();
-        log.info("SSE 구독 요청 둘어옴 (userId={})", userId);
-
-        return sseService.subscribe(userId, lastEventId);
-    }
-
     @PatchMapping("/read")
     public ResponseEntity<CommonResponse> markNotificationsAsRead(
             @AuthenticationPrincipal Claims claims,

--- a/src/main/java/com/groommoa/aether_back_notification/infrastructure/sse/controller/SseController.java
+++ b/src/main/java/com/groommoa/aether_back_notification/infrastructure/sse/controller/SseController.java
@@ -1,0 +1,33 @@
+package com.groommoa.aether_back_notification.infrastructure.sse.controller;
+
+import com.groommoa.aether_back_notification.infrastructure.sse.service.SseService;
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Slf4j
+@RequestMapping("/sse")
+@RequiredArgsConstructor
+@RestController
+public class SseController {
+
+    private final SseService sseService;
+
+    @GetMapping(value="/subscribe", produces= MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter subscribe(
+            @AuthenticationPrincipal Claims claims,
+            @RequestHeader(value="Last-Event-ID", required = false) String lastEventId
+    ) {
+        String userId = claims.getSubject();
+        log.info("SSE 구독 요청 들어옴 (userId={})", userId);
+
+        return sseService.subscribe(userId, lastEventId);
+    }
+}


### PR DESCRIPTION
## Changes

- SSE 구독 엔드포인트를 /notifications/subscribe 에서 /sse/subscribe 로 변경했습니다.
 (관련 PR: #15 )